### PR TITLE
Add option to override Yoast SEO index/noindex setting for all posts when importing

### DIFF
--- a/class.prso-content-synd-toolkit-reader.php
+++ b/class.prso-content-synd-toolkit-reader.php
@@ -87,6 +87,9 @@ class PrsoSyndToolkitReader {
 		//Detect post status override option and override imported post status
 		add_filter( 'wp_import_post_data_processed', array($this, 'override_imported_post_status'), 10, 2 );
 		
+		//Detect post SEO index override option and override imported post SEO index status
+		add_filter( 'wp_import_post_meta', array($this, 'override_imported_post_seo_index_status'), 10, 2 );
+		
 	}
 	
 	/**
@@ -114,6 +117,31 @@ class PrsoSyndToolkitReader {
 		//PrsoSyndToolkitReader::plugin_error_log( $postdata['post_status'] );
 		
 		return $postdata;
+	}
+	
+	/**
+	* override_imported_post_seo_index_status
+	* 
+	* @Called By Filter 'wp_import_post_meta'
+	*
+	* Overrides imported posts SEO index status based on that set in plugin options
+	*
+	* @access 	public
+	* @author	Anthony Eden
+	*/
+	public function override_imported_post_seo_index_status( $postmeta, $post_id, $post ) {
+		
+		//Only override if status set in options is anything other than '0' (default)
+		if( isset(self::$class_config['import_options']['post-seo-noindex']) && ( '0' !== self::$class_config['import_options']['post-seo-noindex'] ) ) {
+			
+            $postmeta[] = array(
+                'key' => '_yoast_wpseo_meta-robots-noindex',
+                'value' => self::$class_config['import_options']['post-seo-noindex'],
+            );
+			
+		}
+        
+		return $postmeta;
 	}
 	
 	/**

--- a/inc/ReduxConfig/ReduxConfig.php
+++ b/inc/ReduxConfig/ReduxConfig.php
@@ -313,6 +313,20 @@ if ( !class_exists( "PrsoSyndToolkitReaderOptions" ) ) {
 					    	'pending'	=>	'Pending',
 					    	'publish'	=>	'Published'
 					    )
+					),
+					array(
+					    'id'       => 'post-seo-noindex',
+					    'type'     => 'select',
+					    'title'    => __('Yoast SEO Index', $this->text_domain),
+					    'placeholder' => __('Select a Yoast SEO Index Setting', $this->text_domain),
+					    'subtitle' => __('Select a Yoast SEO Index Setting for all syndicated content.', $this->text_domain),
+					    'desc'     => __('Override the Yoast SEO Index Setting for all syndicated content.', $this->text_domain),
+					    // Must provide key => value pairs for select options
+					    'options'  => array(
+					    	'0' 		=> 	'Site default',
+					    	'2'		    =>	'Index',
+					    	'1'	        =>	'No Index'
+					    )
 					)
 				)
 			);

--- a/prso-content-synd-toolkit-reader.php
+++ b/prso-content-synd-toolkit-reader.php
@@ -87,6 +87,17 @@ function prso_synd_toolkit_reader_init() {
 		
 	}
 	
+	//Cache post index override option
+	if( isset($prso_synd_toolkit_reader_options['post-seo-noindex']) ) {
+		
+		if( empty($prso_synd_toolkit_reader_options['post-seo-noindex']) ) {
+			$prso_synd_toolkit_reader_options['post-seo-noindex'] = '0';
+		}
+		
+		$config_options['import_options']['post-seo-noindex'] = esc_attr( $prso_synd_toolkit_reader_options['post-seo-noindex'] );
+		
+	}
+	
 	//Instatiate plugin class and pass config options array
 	new PrsoSyndToolkitReader( $config_options );
 		


### PR DESCRIPTION
This pull request allows sites to override the Yoast SEO index/noindex setting for all posts as they are being imported. It adds a new option to the "settings" page, and applies this setting uniformly when importing syndicated posts.
